### PR TITLE
Updates to Rakefile and gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,13 +14,13 @@ namespace 'gem' do
   task :build => [:clean] do
     require 'rubygems/package'
     spec = eval(IO.read('mail-sympa.gemspec'))
-    Gem::Package.build(spec, true)
+    Gem::Package.build(spec)
   end
 
   desc 'Install the mail-sympa gem'
   task :install => [:build] do
     file = Dir["*.gem"].first
-    sh "gem install #{file}"
+    sh "gem install -l #{file}"
   end
 end
 

--- a/mail-sympa.gemspec
+++ b/mail-sympa.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency('soap4r-ruby1.9', '>= 2.0.0')
-  spec.add_development_dependency('test-unit', '>= 3.0.0')
-  spec.add_development_dependency('dbi-dbrc')
+  spec.add_dependency('soap4r-ruby1.9', '~> 2.0')
+  spec.add_development_dependency('test-unit', '~> 3.3')
+  spec.add_development_dependency('dbi-dbrc', '~> 1.4')
 
   spec.summary = <<-EOF
     The mail-sympa library provides a Ruby interface to the Sympa mailing


### PR DESCRIPTION
This PR has two updates to the Rakefile, one where we fix the `install` task to use the `-l` switch to force a local installation, and it also removes the `true` argument to the package task so that it doesn't suppress warnings.

The gemspec was updated to make the versioning a bit more pessimistic, and to avoid build warnings.